### PR TITLE
added -beta to drivers for beta versions of chrome

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -1,21 +1,21 @@
 {
     "drivers": [
         {
-            "name": "chromedriver",
+            "name": "chromedriver-beta",
             "platform": "linux",
             "bit": "64",
             "version": "75.0.3770.8",
             "url": "http://chromedriver.storage.googleapis.com/75.0.3770.8/chromedriver_linux64.zip"
         },
         {
-            "name": "chromedriver",
+            "name": "chromedriver-beta",
             "platform": "mac",
             "bit": "64",
             "version": "75.0.3770.8",
             "url": "http://chromedriver.storage.googleapis.com/75.0.3770.8/chromedriver_mac64.zip"
         },
         {
-            "name": "chromedriver",
+            "name": "chromedriver-beta",
             "platform": "windows",
             "bit": "32",
             "version": "75.0.3770.8",

--- a/src/test/java/com.github.webdriverextensions/RepositoryTest.java
+++ b/src/test/java/com.github.webdriverextensions/RepositoryTest.java
@@ -59,7 +59,7 @@ public class RepositoryTest {
                     .matches("MicrosoftWebDriver.*");
         } else if (isChromeBetaDriver) {
             assertThat(fileName)
-                    .describedAs("url '" + url "' should contain 'chromedriver'")
+                    .describedAs("url '" + url + "' should contain 'chromedriver'")
                     .matches("chromedriver.*");
         } else {
             assertThat(fileName)

--- a/src/test/java/com.github.webdriverextensions/RepositoryTest.java
+++ b/src/test/java/com.github.webdriverextensions/RepositoryTest.java
@@ -59,8 +59,8 @@ public class RepositoryTest {
                     .matches("MicrosoftWebDriver.*");
         } else if (isChromeBetaDriver) {
             assertThat(fileName)
-                    .describedAs("url '" + url "' should contain 'chromedriver')
-                    .matches("chromedriver.*);
+                    .describedAs("url '" + url "' should contain 'chromedriver'")
+                    .matches("chromedriver.*");
         } else {
             assertThat(fileName)
                     .describedAs("url '" + url + "' should contain name '" + name + "'")

--- a/src/test/java/com.github.webdriverextensions/RepositoryTest.java
+++ b/src/test/java/com.github.webdriverextensions/RepositoryTest.java
@@ -48,6 +48,7 @@ public class RepositoryTest {
         String fileName = Paths.get(uri.getPath()).getFileName().toString();
         boolean isIEDriver = "internetexplorerdriver".equals(name);
         boolean isEdgeDriver = "edgedriver".equals(name);
+        boolean isChromeBetaDriver = "chromedriver-beta".equals(name);
         if (isIEDriver) {
             assertThat(fileName)
                     .describedAs("url '" + url + "' should contain name 'IEDriverServer_'")
@@ -56,6 +57,10 @@ public class RepositoryTest {
             assertThat(fileName)
                     .describedAs("url '" + url + "' should contain name 'MicrosoftWebDriver'")
                     .matches("MicrosoftWebDriver.*");
+        } else if (isChromeBetaDriver) {
+            assertThat(fileName)
+                    .describedAs("url '" + url "' should contain 'chromedriver')
+                    .matches("chromedriver.*);
         } else {
             assertThat(fileName)
                     .describedAs("url '" + url + "' should contain name '" + name + "'")


### PR DESCRIPTION
This is so that people can use just chromedriver to get the driver for the latest release and chromedriver-beta for the future releases. The idea would be to maintain the -beta tag for whichever driver is beta and as versions of chrome get fully released we remove it.