### PR TITLE
Chromedriver: take version 75 out of beta and add 76 as beta

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4,22 +4,43 @@
             "name": "chromedriver-beta",
             "platform": "linux",
             "bit": "64",
-            "version": "75.0.3770.8",
-            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.8/chromedriver_linux64.zip"
+            "version": "76.0.3809.25",
+            "url": "http://chromedriver.storage.googleapis.com/76.0.3809.25/chromedriver_linux64.zip"
         },
         {
             "name": "chromedriver-beta",
             "platform": "mac",
             "bit": "64",
-            "version": "75.0.3770.8",
-            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.8/chromedriver_mac64.zip"
+            "version": "76.0.3809.25",
+            "url": "http://chromedriver.storage.googleapis.com/76.0.3809.25/chromedriver_mac64.zip"
         },
         {
             "name": "chromedriver-beta",
             "platform": "windows",
             "bit": "32",
-            "version": "75.0.3770.8",
-            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.8/chromedriver_win32.zip"
+            "version": "76.0.3809.25",
+            "url": "http://chromedriver.storage.googleapis.com/76.0.3809.25/chromedriver_win32.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "linux",
+            "bit": "64",
+            "version": "75.0.3770.90",
+            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_linux64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "version": "75.0.3770.90",
+            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "windows",
+            "bit": "32",
+            "version": "75.0.3770.90",
+            "url": "http://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_win32.zip"
         },
         {
             "name": "chromedriver",


### PR DESCRIPTION
Note that I also updated 75 from 75.0.3770.8 to 75.0.3770.90. I don't know if we want every minor version in the repository as well?