### PR TITLE
76 Added fileMatchInside parameter for Edge Chromium and Opera.

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -3015,378 +3015,432 @@
             "platform": "windows",
             "bit": "32",
             "version": "80.0.361.47",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "80.0.361.47",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "80.0.361.47",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "80.0.361.48",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "80.0.361.48",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "80.0.361.48",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "80.0.361.50",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "80.0.361.50",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "80.0.361.50",
-            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "81.0.415.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "81.0.415.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "81.0.415.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "81.0.416.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "81.0.416.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "81.0.416.0",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "81.0.416.3",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "81.0.416.3",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "81.0.416.3",
-            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "82.0.418.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "82.0.418.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "82.0.418.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "82.0.421.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "82.0.421.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "82.0.421.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "82.0.422.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "82.0.422.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "82.0.422.0",
-            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "84.0.522.52",
-            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "84.0.522.52",
-            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "84.0.522.52",
-            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "85.0.564.17",
-            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "85.0.564.17",
-            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "85.0.564.17",
-            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "32",
             "version": "86.0.601.0",
-            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win32.zip"
+            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win32.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
             "version": "86.0.601.0",
-            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win64.zip"
+            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "version": "86.0.601.0",
-            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_mac64.zip"
+            "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_mac64.zip",
+            "fileMatchInside": "msedgedriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "64",
             "version": "2.30",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "32",
             "version": "2.30",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "64",
             "version": "2.30",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_linux64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_linux64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "mac",
             "bit": "64",
             "version": "2.30",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_mac64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_mac64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "64",
             "version": "2.29",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "32",
             "version": "2.29",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "64",
             "version": "2.29",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_linux64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_linux64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "mac",
             "bit": "64",
             "version": "2.29",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_mac64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_mac64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "64",
             "version": "2.27",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "32",
             "version": "2.27",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "64",
             "version": "2.27",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "32",
             "version": "2.27",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "mac",
             "bit": "64",
             "version": "2.27",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_mac64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_mac64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "32",
             "version": "0.2.2",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "windows",
             "bit": "64",
             "version": "0.2.2",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "mac",
             "bit": "64",
             "version": "0.2.2",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_mac64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_mac64.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "32",
             "version": "0.2.2",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux32.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux32.zip",
+            "fileMatchInside": "operadriver.*"
         },
         {
             "name": "operadriver",
             "platform": "linux",
             "bit": "64",
             "version": "0.2.2",
-            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux64.zip"
+            "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux64.zip",
+            "fileMatchInside": "operadriver.*"
         }
     ]
 }

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -3016,7 +3016,7 @@
             "bit": "32",
             "version": "80.0.361.47",
             "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3024,7 +3024,7 @@
             "bit": "64",
             "version": "80.0.361.47",
             "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3032,7 +3032,7 @@
             "bit": "64",
             "version": "80.0.361.47",
             "url": "https://msedgedriver.azureedge.net/80.0.361.47/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3040,7 +3040,7 @@
             "bit": "32",
             "version": "80.0.361.48",
             "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3048,7 +3048,7 @@
             "bit": "64",
             "version": "80.0.361.48",
             "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3056,7 +3056,7 @@
             "bit": "64",
             "version": "80.0.361.48",
             "url": "https://msedgedriver.azureedge.net/80.0.361.48/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3064,7 +3064,7 @@
             "bit": "32",
             "version": "80.0.361.50",
             "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3072,7 +3072,7 @@
             "bit": "64",
             "version": "80.0.361.50",
             "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3080,7 +3080,7 @@
             "bit": "64",
             "version": "80.0.361.50",
             "url": "https://msedgedriver.azureedge.net/80.0.361.50/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3088,7 +3088,7 @@
             "bit": "32",
             "version": "81.0.415.0",
             "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3096,7 +3096,7 @@
             "bit": "64",
             "version": "81.0.415.0",
             "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3104,7 +3104,7 @@
             "bit": "64",
             "version": "81.0.415.0",
             "url": "https://msedgedriver.azureedge.net/81.0.415.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3112,7 +3112,7 @@
             "bit": "32",
             "version": "81.0.416.0",
             "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3120,7 +3120,7 @@
             "bit": "64",
             "version": "81.0.416.0",
             "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3128,7 +3128,7 @@
             "bit": "64",
             "version": "81.0.416.0",
             "url": "https://msedgedriver.azureedge.net/81.0.416.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3136,7 +3136,7 @@
             "bit": "32",
             "version": "81.0.416.3",
             "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3144,7 +3144,7 @@
             "bit": "64",
             "version": "81.0.416.3",
             "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3152,7 +3152,7 @@
             "bit": "64",
             "version": "81.0.416.3",
             "url": "https://msedgedriver.azureedge.net/81.0.416.3/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3160,7 +3160,7 @@
             "bit": "32",
             "version": "82.0.418.0",
             "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3168,7 +3168,7 @@
             "bit": "64",
             "version": "82.0.418.0",
             "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3176,7 +3176,7 @@
             "bit": "64",
             "version": "82.0.418.0",
             "url": "https://msedgedriver.azureedge.net/82.0.418.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3184,7 +3184,7 @@
             "bit": "32",
             "version": "82.0.421.0",
             "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3192,7 +3192,7 @@
             "bit": "64",
             "version": "82.0.421.0",
             "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3200,7 +3200,7 @@
             "bit": "64",
             "version": "82.0.421.0",
             "url": "https://msedgedriver.azureedge.net/82.0.421.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3208,7 +3208,7 @@
             "bit": "32",
             "version": "82.0.422.0",
             "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3216,7 +3216,7 @@
             "bit": "64",
             "version": "82.0.422.0",
             "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3224,7 +3224,7 @@
             "bit": "64",
             "version": "82.0.422.0",
             "url": "https://msedgedriver.azureedge.net/82.0.422.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3232,7 +3232,7 @@
             "bit": "32",
             "version": "84.0.522.52",
             "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3240,7 +3240,7 @@
             "bit": "64",
             "version": "84.0.522.52",
             "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3248,7 +3248,7 @@
             "bit": "64",
             "version": "84.0.522.52",
             "url": "https://msedgedriver.azureedge.net/84.0.522.52/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3256,7 +3256,7 @@
             "bit": "32",
             "version": "85.0.564.17",
             "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3264,7 +3264,7 @@
             "bit": "64",
             "version": "85.0.564.17",
             "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3272,7 +3272,7 @@
             "bit": "64",
             "version": "85.0.564.17",
             "url": "https://msedgedriver.azureedge.net/85.0.564.17/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3280,7 +3280,7 @@
             "bit": "32",
             "version": "86.0.601.0",
             "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win32.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3288,7 +3288,7 @@
             "bit": "64",
             "version": "86.0.601.0",
             "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_win64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "edgedriver",
@@ -3296,7 +3296,7 @@
             "bit": "64",
             "version": "86.0.601.0",
             "url": "https://msedgedriver.azureedge.net/86.0.601.0/edgedriver_mac64.zip",
-            "fileMatchInside": "msedgedriver.*"
+            "fileMatchInside": ".*msedgedriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3304,7 +3304,7 @@
             "bit": "64",
             "version": "2.30",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3312,7 +3312,7 @@
             "bit": "32",
             "version": "2.30",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3320,7 +3320,7 @@
             "bit": "64",
             "version": "2.30",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_linux64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3328,7 +3328,7 @@
             "bit": "64",
             "version": "2.30",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_mac64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3336,7 +3336,7 @@
             "bit": "64",
             "version": "2.29",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3344,7 +3344,7 @@
             "bit": "32",
             "version": "2.29",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_win32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3352,7 +3352,7 @@
             "bit": "64",
             "version": "2.29",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_linux64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3360,7 +3360,7 @@
             "bit": "64",
             "version": "2.29",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.29/operadriver_mac64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3368,7 +3368,7 @@
             "bit": "64",
             "version": "2.27",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3376,7 +3376,7 @@
             "bit": "32",
             "version": "2.27",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_win32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3384,7 +3384,7 @@
             "bit": "64",
             "version": "2.27",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3392,7 +3392,7 @@
             "bit": "32",
             "version": "2.27",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_linux32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3400,7 +3400,7 @@
             "bit": "64",
             "version": "2.27",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.27/operadriver_mac64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3408,7 +3408,7 @@
             "bit": "32",
             "version": "0.2.2",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3416,7 +3416,7 @@
             "bit": "64",
             "version": "0.2.2",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_win64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3424,7 +3424,7 @@
             "bit": "64",
             "version": "0.2.2",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_mac64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3432,7 +3432,7 @@
             "bit": "32",
             "version": "0.2.2",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux32.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         },
         {
             "name": "operadriver",
@@ -3440,7 +3440,7 @@
             "bit": "64",
             "version": "0.2.2",
             "url": "https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_linux64.zip",
-            "fileMatchInside": "operadriver.*"
+            "fileMatchInside": ".*operadriver(.exe)?$"
         }
     ]
 }


### PR DESCRIPTION
Added `fileMatchInside` for Edge and Opera. Ran this file as the repository file in the tests for `webdriverextensions-maven-plugin` where I also readded the assertsions for `operadriver` again. Worked like a charm for the tests I ran.