### PR TITLE
add chromedriver 96.0.4664.45

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4,6 +4,27 @@
             "name": "chromedriver",
             "platform": "windows",
             "bit": "32",
+            "version": "96.0.4664.45",
+            "url": "https://chromedriver.storage.googleapis.com/96.0.4664.45/chromedriver_win32.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "version": "96.0.4664.45",
+            "url": "https://chromedriver.storage.googleapis.com/96.0.4664.45/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "linux",
+            "bit": "64",
+            "version": "96.0.4664.45",
+            "url": "https://chromedriver.storage.googleapis.com/96.0.4664.45/chromedriver_linux64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "windows",
+            "bit": "32",
             "version": "95.0.4638.17",
             "url": "https://chromedriver.storage.googleapis.com/95.0.4638.17/chromedriver_win32.zip"
         },


### PR DESCRIPTION
add chromedriver in version 96.0.4664.45 for linux/mac/win32
from https://chromedriver.storage.googleapis.com/index.html?path=96.0.4664.45/