### PR TITLE
Add M1 Mac driver for GoogleChrome 95.0.4638.17

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -16,6 +16,13 @@
         },
         {
             "name": "chromedriver",
+            "platform": "mac",
+            "bit": "arm64",
+            "version": "95.0.4638.17",
+            "url": "https://chromedriver.storage.googleapis.com/95.0.4638.17/chromedriver_mac64_m1.zip"
+        },
+        {
+            "name": "chromedriver",
             "platform": "linux",
             "bit": "64",
             "version": "95.0.4638.17",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -2529,6 +2529,13 @@
         },
         {
             "name": "geckodriver",
+            "platform": "mac",
+            "bit": "arm64",
+            "version": "0.30.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-macos-aarch64.tar.gz"
+        },
+        {
+            "name": "geckodriver",
             "platform": "windows",
             "bit": "64",
             "version": "0.29.1",


### PR DESCRIPTION
Add M1 Mac driver for GoogleChrome 95.0.4638.17