### PR TITLE
Add driver entries for Apple Silicon M1

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -310,6 +310,13 @@
         },
         {
             "name": "chromedriver",
+            "platform": "mac",
+            "bit": "arm64",
+            "version": "95.0.4638.17",
+            "url": "https://chromedriver.storage.googleapis.com/95.0.4638.17/chromedriver_mac64_m1.zip"
+        },
+        {
+            "name": "chromedriver",
             "platform": "linux",
             "bit": "64",
             "version": "95.0.4638.17",
@@ -2848,6 +2855,13 @@
             "bit": "64",
             "version": "0.30.0",
             "url": "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-macos.tar.gz"
+        },
+        {
+            "name": "geckodriver",
+            "platform": "mac",
+            "bit": "arm64",
+            "version": "0.30.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-macos-aarch64.tar.gz"
         },
         {
             "name": "geckodriver",


### PR DESCRIPTION
I do rely heavily on the usage of the [webdriver-binaries-gradle-plugin](https://github.com/erdi/webdriver-binaries-gradle-plugin), which is more or less a groovy implementation of the existing maven plugin. Both use this repository as their source for the available driver binaries. The gradle plugin is already able to identify the M1 architecture as arm64, but there are no definitions present in this repository yet. 

I was able to configure a local json file as the source instead using the `driverUrlsConfiguration` property, but i'd prefer to use the public repository instead.

* add 0.30.0 geckodriver for arm64
* add 95.0.4638.17 chromedriver for arm64