### PR TITLE
add AARCH64 drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,62 @@ This is the home of the drivers repository used by the [WebDriver Extensions Mav
 Simply just fork this repo, add the driver info in the [repository-3.0.json](https://github.com/webdriverextensions/webdriverextensions-maven-plugin-repository/blob/master/repository-3.0.json) file and do a PR. 
 No need to add the drivers to repository.json since that repo is no longer maintained.
 
+### How does an entry of a driver look like?
+The repository JSON must be validated against [the driver schema](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/blob/master/drivers-schema.json). Each driver entry is an object with the following properties (*the ones in bold are required*).
+
+- **`name`**: the name of the driver. one of "chromedriver", "edgedriver", "geckodriver", "internetexplorerdriver", "operadriver" or "phantomjs"
+- **`platform`**: the operating system. one of "linux", "windows" or "mac"
+- **`bit`**: "64" for 64-bit or "32" for 32-bit
+- **`version`**: the actual version of the driver
+- **`url`**: the URL where the driver can be downloaded. compressed files and archives of the following types are supported: `.gz`, `.bz`, `.tar`, `.tar.gz`, `.tar.bz`, `.zip`
+- `arch`: driver os/cpu architecture. one of "x86", "amd64", "aarch64" or "ia64"
+- `fileMatchInside`: a regular expression to select only the files that match the specified pattern
+- `customFileName`: a custom name for the driver file in the installation directory
+
+**Example**
+```json
+{
+    "name": "edgedriver",
+    "platform": "windows",
+    "bit": "64",
+    "arch": "amd64",
+    "version": "108.0.1462.38",
+    "fileMatchInside": "^msedgedriver\\.exe$",
+    "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_win64.zip"
+}
+```
+
+#### A note about the `arch` property
+If there is only one variant of a driver for a given platform and bit, the property can be omitted.
+
+If there is more than one variant of a driver for a certain platform and bit, e.g. edgedriver for Windows 64-bit and the architectures "amd64" and "aarch64" (M1), then both entries must contain the `arch` property and the "amd64" variant must be first!
+
+**Example**
+```json
+{
+...
+	{
+	    "name": "edgedriver",
+	    "platform": "windows",
+	    "bit": "64",
+	    "arch": "amd64",
+	    "version": "108.0.1462.38",
+	    "fileMatchInside": "^msedgedriver\\.exe$",
+	    "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_win64.zip"
+	},
+	{
+	    "name": "edgedriver",
+	    "platform": "windows",
+	    "bit": "64",
+	    "arch": "aarch64",
+	    "version": "108.0.1462.38",
+	    "fileMatchInside": "^msedgedriver\\.exe$",
+	    "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_arm64.zip"
+	}
+...
+}
+```
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <project.java.version>17</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <junit.version>5.8.2</junit.version>
-        <lombok.version>1.18.22</lombok.version>
+        <junit.version>5.9.1</junit.version>
+        <lombok.version>1.18.24</lombok.version>
     </properties>
 
     <dependencies>
@@ -41,20 +41,14 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.21.0</version>
+            <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.0.72</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -63,28 +57,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${project.java.version}</source>
                     <target>${project.java.version}</target>
+                    <release>${project.java.version}</release>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>
                     </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4330,9 +4330,19 @@
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
+            "arch": "amd64",
             "version": "107.0.1418.62",
             "fileMatchInside": "^msedgedriver\\.exe$",
             "url": "https://msedgedriver.azureedge.net/107.0.1418.62/edgedriver_win64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "107.0.1418.62",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/107.0.1418.62/edgedriver_arm64.zip"
         },
         {
             "name": "edgedriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -2924,8 +2924,17 @@
             "name": "geckodriver",
             "platform": "windows",
             "bit": "64",
+            "arch": "amd64",
             "version": "0.32.0",
             "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-win64.zip"
+        },
+        {
+            "name": "geckodriver",
+            "platform": "windows",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "0.32.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-win-aarch64.zip"
         },
         {
             "name": "geckodriver",
@@ -2938,8 +2947,17 @@
             "name": "geckodriver",
             "platform": "linux",
             "bit": "64",
+            "arch": "amd64",
             "version": "0.32.0",
             "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz"
+        },
+        {
+            "name": "geckodriver",
+            "platform": "linux",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "0.32.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux-aarch64.tar.gz"
         },
         {
             "name": "geckodriver",
@@ -2952,8 +2970,17 @@
             "name": "geckodriver",
             "platform": "mac",
             "bit": "64",
+            "arch": "amd64",
             "version": "0.32.0",
             "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-macos.tar.gz"
+        },
+        {
+            "name": "geckodriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "0.32.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-macos-aarch64.tar.gz"
         },
         {
             "name": "geckodriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4119,6 +4119,54 @@
             "url": "https://msedgedriver.azureedge.net/103.0.1264.77/edgedriver_linux64.zip"
         },
         {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "32",
+            "version": "105.0.1343.53",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_win32.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "64",
+            "arch": "amd64",
+            "version": "105.0.1343.53",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_win64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "105.0.1343.53",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_arm64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "mac",
+            "bit": "64",
+            "version": "105.0.1343.53",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_mac64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "105.0.1343.53",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_mac64_m1.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "linux",
+            "bit": "64",
+            "version": "105.0.1343.53",
+            "url": "https://msedgedriver.azureedge.net/105.0.1343.53/edgedriver_linux64.zip"
+        },
+        {
             "name": "operadriver",
             "platform": "windows",
             "bit": "64",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -11,8 +11,17 @@
             "name": "chromedriver",
             "platform": "mac",
             "bit": "64",
+            "arch": "amd64",
             "version": "105.0.5195.52",
             "url": "https://chromedriver.storage.googleapis.com/105.0.5195.52/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "105.0.5195.52",
+            "url": "https://chromedriver.storage.googleapis.com/105.0.5195.52/chromedriver_mac64_m1.zip"
         },
         {
             "name": "chromedriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4368,32 +4368,42 @@
             "name": "edgedriver",
             "platform": "windows",
             "bit": "64",
+            "arch": "amd64",
             "version": "108.0.1462.38",
             "fileMatchInside": "^msedgedriver\\.exe$",
             "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_win64.zip"
         },
         {
             "name": "edgedriver",
+            "platform": "windows",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "108.0.1462.38",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_arm64.zip"
+        },
+        {
+            "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "arch": "amd64",
-            "version": "108.0.1462.42",
-            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_mac64.zip"
+            "version": "108.0.1462.41",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.41/edgedriver_mac64.zip"
         },
         {
             "name": "edgedriver",
             "platform": "mac",
             "bit": "64",
             "arch": "aarch64",
-            "version": "108.0.1462.42",
-            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_mac64_m1.zip"
+            "version": "108.0.1462.41",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.41/edgedriver_mac64_m1.zip"
         },
         {
             "name": "edgedriver",
             "platform": "linux",
             "bit": "64",
-            "version": "108.0.1462.38",
-            "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_linux64.zip"
+            "version": "108.0.1462.42",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_linux64.zip"
         },
         {
             "name": "operadriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -2862,8 +2862,17 @@
             "name": "geckodriver",
             "platform": "mac",
             "bit": "64",
+            "arch": "amd64",
             "version": "0.31.0",
             "url": "https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-macos.tar.gz"
+        },
+        {
+            "name": "geckodriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "0.31.0",
+            "url": "https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-macos-aarch64.tar.gz"
         },
         {
             "name": "geckodriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -11,8 +11,17 @@
             "name": "chromedriver",
             "platform": "mac",
             "bit": "64",
+            "arch": "amd64",
             "version": "108.0.5359.71",
             "url": "https://chromedriver.storage.googleapis.com/108.0.5359.71/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "108.0.5359.71",
+            "url": "https://chromedriver.storage.googleapis.com/108.0.5359.71/chromedriver_mac_arm64.zip"
         },
         {
             "name": "chromedriver",
@@ -25,22 +34,31 @@
             "name": "chromedriver",
             "platform": "windows",
             "bit": "32",
-            "version": "107.0.5304.18",
-            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.18/chromedriver_win32.zip"
+            "version": "107.0.5304.62",
+            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_win32.zip"
         },
         {
             "name": "chromedriver",
             "platform": "mac",
             "bit": "64",
-            "version": "107.0.5304.18",
-            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.18/chromedriver_mac64.zip"
+            "arch": "amd64",
+            "version": "107.0.5304.62",
+            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "107.0.5304.62",
+            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_mac_arm64.zip"
         },
         {
             "name": "chromedriver",
             "platform": "linux",
             "bit": "64",
-            "version": "107.0.5304.18",
-            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.18/chromedriver_linux64.zip"
+            "version": "107.0.5304.62",
+            "url": "https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip"
         },
         {
             "name": "chromedriver",
@@ -53,8 +71,17 @@
             "name": "chromedriver",
             "platform": "mac",
             "bit": "64",
+            "arch": "amd64",
             "version": "106.0.5249.61",
             "url": "https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_mac64.zip"
+        },
+        {
+            "name": "chromedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "106.0.5249.61",
+            "url": "https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_mac_arm64.zip"
         },
         {
             "name": "chromedriver",
@@ -4301,6 +4328,45 @@
             "bit": "64",
             "version": "107.0.1418.62",
             "url": "https://msedgedriver.azureedge.net/107.0.1418.62/edgedriver_linux64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "32",
+            "version": "108.0.1462.38",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_win32.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "windows",
+            "bit": "64",
+            "version": "108.0.1462.38",
+            "fileMatchInside": "^msedgedriver\\.exe$",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_win64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "amd64",
+            "version": "108.0.1462.42",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_mac64.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "mac",
+            "bit": "64",
+            "arch": "aarch64",
+            "version": "108.0.1462.42",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.42/edgedriver_mac64_m1.zip"
+        },
+        {
+            "name": "edgedriver",
+            "platform": "linux",
+            "bit": "64",
+            "version": "108.0.1462.38",
+            "url": "https://msedgedriver.azureedge.net/108.0.1462.38/edgedriver_linux64.zip"
         },
         {
             "name": "operadriver",


### PR DESCRIPTION
preparation for the upcoming release v3.4.0 of webdriverextensions-maven-plugin

- adds AARCH64 variants for geckodriver, chromedriver and edgedriver
- adds geckodriver 0.32.0
- adds edgedriver 108
- updates chromedriver and edgedriver 107