### PR TITLE
Update repository-3.0.json

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -5,7 +5,7 @@
         	"platform": "windows",
         	"bit": "32",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win32/chromedriver-win32.zip" 
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win32/chromedriver-win32.zip",
         	"fileMatchInside": ".*chromedriver.exe$"
         },
         {
@@ -13,7 +13,7 @@
         	"platform": "windows",
         	"bit": "32",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win64/chromedriver-win64.zip" 
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win64/chromedriver-win64.zip",
         	"fileMatchInside": ".*chromedriver.exe$"
         },
         {
@@ -22,7 +22,7 @@
         	"bit": "64",
         	"arch": "amd64",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip"
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {
@@ -31,7 +31,7 @@
         	"bit": "64",
         	"arch": "aarch64",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip"
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {
@@ -39,7 +39,7 @@
         	"platform": "linux",
         	"bit": "64",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip"
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -22,7 +22,7 @@
         	"bit": "64",
         	"arch": "amd64",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {
@@ -31,7 +31,7 @@
         	"bit": "64",
         	"arch": "aarch64",
         	"version": "116.0.5845.96",
-        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -6,6 +6,15 @@
         	"bit": "32",
         	"version": "116.0.5845.96",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win32/chromedriver-win32.zip" 
+        	"fileMatchInside": ".*chromedriver.exe$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "windows",
+        	"bit": "32",
+        	"version": "116.0.5845.96",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win64/chromedriver-win64.zip" 
+        	"fileMatchInside": ".*chromedriver.exe$"
         },
         {
         	"name": "chromedriver",
@@ -14,6 +23,7 @@
         	"arch": "amd64",
         	"version": "116.0.5845.96",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip"
+        	"fileMatchInside": ".*chromedriver$"
         },
         {
         	"name": "chromedriver",
@@ -22,6 +32,7 @@
         	"arch": "aarch64",
         	"version": "116.0.5845.96",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip"
+        	"fileMatchInside": ".*chromedriver$"
         },
         {
         	"name": "chromedriver",
@@ -29,6 +40,7 @@
         	"bit": "64",
         	"version": "116.0.5845.96",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip"
+        	"fileMatchInside": ".*chromedriver$"
         },
         {
             "name": "geckodriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -11,7 +11,7 @@
         {
         	"name": "chromedriver",
         	"platform": "windows",
-        	"bit": "32",
+        	"bit": "64",
         	"version": "116.0.5845.96",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win64/chromedriver-win64.zip",
         	"fileMatchInside": ".*chromedriver.exe$"

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -1,6 +1,36 @@
 {
     "drivers": [
         {
+        	"name": "chromedriver",
+        	"platform": "windows",
+        	"bit": "32",
+        	"version": "116.0.5845.96",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/win32/chromedriver-win32.zip" 
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "mac",
+        	"bit": "64",
+        	"arch": "amd64",
+        	"version": "116.0.5845.96",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-arm64/chromedriver-mac-arm64.zip"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "mac",
+        	"bit": "64",
+        	"arch": "aarch64",
+        	"version": "116.0.5845.96",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/mac-x64/chromedriver-mac-x64.zip"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "linux",
+        	"bit": "64",
+        	"version": "116.0.5845.96",
+        	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip"
+        },
+        {
             "name": "geckodriver",
             "platform": "windows",
             "bit": "64",


### PR DESCRIPTION
Added chrome driver version 116.0.5845.96 for:

Windows
Linux
Intel mac x64
Apple Silicon mac x64

Note that since M115 chromedriver release process is integraterd with that of chrome, from the web (https://chromedriver.chromium.org/downloads/version-selection)

> Starting with M115 the ChromeDriver release process is integrated with that of Chrome. The latest Chrome + ChromeDriver releases per release channel (Stable, Beta, Dev, Canary) are available at[ the Chrome for Testing (CfT) availability dashboard](https://googlechromelabs.github.io/chrome-for-testing/). As a result, you might no longer have a need for version selection — you could choose any available CfT version and simply download the correspondingly-versioned ChromeDriver binary.

So the urls added changed from the https://chromedriver.storage.googleapis.com to https://edgedl.me.gvt1.com 

There is also a difference in the zip structure (at least for windows), the old ones the driver is directly in the root, however in the new zip there is a root folder and driver inside. 

Depends on how you are dealing with the driver, this could produce a problem like happens with the gradle plugin https://github.com/erdi/webdriver-binaries-gradle-plugin which implements a change in version 3.2 in order to solve it
* https://github.com/erdi/webdriver-binaries-gradle-plugin/pull/40 
* https://github.com/erdi/webdriver-binaries-gradle-plugin/pull/39