### PR TITLE
Added chromedriver 126.0.6478.126

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -4,6 +4,48 @@
         	"name": "chromedriver",
         	"platform": "windows",
         	"bit": "32",
+        	"version": "126.0.6478.126",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win32/chrome-win32.zip",
+        	"fileMatchInside": ".*chromedriver.exe$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "windows",
+        	"bit": "64",
+        	"version": "126.0.6478.126",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win64/chrome-win64.zip",
+        	"fileMatchInside": ".*chromedriver.exe$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "mac",
+        	"bit": "64",
+        	"arch": "amd64",
+        	"version": "126.0.6478.126",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-x64/chrome-mac-x64.zip",
+        	"fileMatchInside": ".*chromedriver$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "mac",
+        	"bit": "64",
+        	"arch": "aarch64",
+        	"version": "126.0.6478.126",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-arm64/chrome-mac-arm64.zip",
+        	"fileMatchInside": ".*chromedriver$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "linux",
+        	"bit": "64",
+        	"version": "126.0.6478.126",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/linux64/chrome-linux64.zip",
+        	"fileMatchInside": ".*chromedriver$"
+        },
+        {
+        	"name": "chromedriver",
+        	"platform": "windows",
+        	"bit": "32",
         	"version": "122.0.6260.0",
         	"url": "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/122.0.6260.0/win32/chromedriver-win32.zip",
         	"fileMatchInside": ".*chromedriver.exe$"

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -5,7 +5,7 @@
         	"platform": "windows",
         	"bit": "32",
         	"version": "126.0.6478.126",
-        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win32/chrome-win32.zip",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win32/chromedriver-win32.zip",
         	"fileMatchInside": ".*chromedriver.exe$"
         },
         {
@@ -13,7 +13,7 @@
         	"platform": "windows",
         	"bit": "64",
         	"version": "126.0.6478.126",
-        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win64/chrome-win64.zip",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/win64/chromedriver-win64.zip",
         	"fileMatchInside": ".*chromedriver.exe$"
         },
         {
@@ -22,7 +22,7 @@
         	"bit": "64",
         	"arch": "amd64",
         	"version": "126.0.6478.126",
-        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-x64/chrome-mac-x64.zip",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-x64/chromedriver-mac-x64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {
@@ -31,7 +31,7 @@
         	"bit": "64",
         	"arch": "aarch64",
         	"version": "126.0.6478.126",
-        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-arm64/chrome-mac-arm64.zip",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/mac-arm64/chromedriver-mac-arm64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {
@@ -39,7 +39,7 @@
         	"platform": "linux",
         	"bit": "64",
         	"version": "126.0.6478.126",
-        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/linux64/chrome-linux64.zip",
+        	"url": "https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/linux64/chromedriver-linux64.zip",
         	"fileMatchInside": ".*chromedriver$"
         },
         {


### PR DESCRIPTION
The domain name for chromedriver downloads seems to have changed:

https://googlechromelabs.github.io/chrome-for-testing/#stable