### PR TITLE
add edgedriver 130/129, chromedriver 130 and geckodriver 0.35.0

### DIFF
--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -1,6 +1,97 @@
 {
     "drivers": [
         {
+          "name": "edgedriver",
+          "platform": "windows",
+          "bit": "32",
+          "version": "130.0.2849.46",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/130.0.2849.46/edgedriver_win32.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "130.0.2849.46",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/130.0.2849.46/edgedriver_win64.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "130.0.2849.46",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/130.0.2849.46/edgedriver_arm64.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "129.0.2792.98",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_mac64.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "129.0.2792.98",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_mac64_m1.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "linux",
+          "bit": "64",
+          "version": "129.0.2792.98",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_linux64.zip"
+        },
+        {
+          "name": "chromedriver",
+          "platform": "windows",
+          "bit": "32",
+          "version": "130.0.6723.59",
+          "url": "https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.59/win32/chromedriver-win32.zip",
+          "fileMatchInside": ".*chromedriver.exe$"
+        },
+        {
+          "name": "chromedriver",
+          "platform": "windows",
+          "bit": "64",
+          "version": "130.0.6723.59",
+          "url": "https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.59/win64/chromedriver-win64.zip",
+          "fileMatchInside": ".*chromedriver.exe$"
+        },
+        {
+          "name": "chromedriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "130.0.6723.59",
+          "url": "https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.59/mac-x64/chromedriver-mac-x64.zip",
+          "fileMatchInside": ".*chromedriver$"
+        },
+        {
+          "name": "chromedriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "130.0.6723.59",
+          "url": "https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.59/mac-arm64/chromedriver-mac-arm64.zip",
+          "fileMatchInside": ".*chromedriver$"
+        },
+        {
+          "name": "chromedriver",
+          "platform": "linux",
+          "bit": "64",
+          "version": "130.0.6723.59",
+          "url": "https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.59/linux64/chromedriver-linux64.zip",
+          "fileMatchInside": ".*chromedriver$"
+        },
+        {
         	"name": "chromedriver",
         	"platform": "windows",
         	"bit": "32",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -90,26 +90,52 @@
         },
         {
           "name": "edgedriver",
+          "platform": "windows",
+          "bit": "32",
+          "version": "129.0.2792.65",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_win32.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "129.0.2792.65",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_win64.zip"
+        },
+        {
+          "name": "edgedriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "129.0.2792.65",
+          "fileMatchInside": "^msedgedriver\\.exe$",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_arm64.zip"
+        },
+        {
+          "name": "edgedriver",
           "platform": "mac",
           "bit": "64",
           "arch": "amd64",
-          "version": "129.0.2792.98",
-          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_mac64.zip"
+          "version": "129.0.2792.65",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_mac64.zip"
         },
         {
           "name": "edgedriver",
           "platform": "mac",
           "bit": "64",
           "arch": "aarch64",
-          "version": "129.0.2792.98",
-          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_mac64_m1.zip"
+          "version": "129.0.2792.65",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_mac64_m1.zip"
         },
         {
           "name": "edgedriver",
           "platform": "linux",
           "bit": "64",
-          "version": "129.0.2792.98",
-          "url": "https://msedgedriver.azureedge.net/129.0.2792.98/edgedriver_linux64.zip"
+          "version": "129.0.2792.65",
+          "url": "https://msedgedriver.azureedge.net/129.0.2792.65/edgedriver_linux64.zip"
         },
         {
           "name": "chromedriver",

--- a/repository-3.0.json
+++ b/repository-3.0.json
@@ -1,6 +1,68 @@
 {
     "drivers": [
         {
+          "name": "geckodriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-win64.zip"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "windows",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-win-aarch64.zip"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "windows",
+          "bit": "32",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-win32.zip"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "linux",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-linux64.tar.gz"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "linux",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-linux-aarch64.tar.gz"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "linux",
+          "bit": "32",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-linux32.tar.gz"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "amd64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-macos.tar.gz"
+        },
+        {
+          "name": "geckodriver",
+          "platform": "mac",
+          "bit": "64",
+          "arch": "aarch64",
+          "version": "0.35.0",
+          "url": "https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-macos-aarch64.tar.gz"
+        },
+        {
           "name": "edgedriver",
           "platform": "windows",
           "bit": "32",


### PR DESCRIPTION
The first five 130.x.x.x Edge releases are not available for macOS or Linux.  129.0.2792.65 is the latest common version for those OSes.  

For Windows edgedriver 130.0.2849.46 is listed so there is a 130.x.x.x version available. 

Version 130.0.2849.46
Released on October 17, 2024, this version includes the latest updates from the Chromium project and fixes for bugs and performance issues.
Version 130.0.2849.43
Released on October 16, 2024, this version fixes bugs and performance issues.
Version 130.0.2849.35
Released on October 11, 2024, this version fixes bugs and performance issues, and includes feature and policy updates.
Version 130.0.2849.27
Released on October 7, 2024, this version fixes bugs and performance issues.
Version 130.0.2849.13
Released on September 30, 2024, this version fixes bugs and performance issues

https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel






